### PR TITLE
Added main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-toggle",
   "description": "Bootstrap Toggle is a highly flexible Bootstrap plugin that converts checkboxes into toggles",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "js/bootstrap-toggle.js",
   "keywords": [
     "bootstrap",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bootstrap-toggle",
   "description": "Bootstrap Toggle is a highly flexible Bootstrap plugin that converts checkboxes into toggles",
   "version": "2.2.1",
+  "main": "js/bootstrap-toggle.js",
   "keywords": [
     "bootstrap",
     "toggle",


### PR DESCRIPTION
Added "main" property, needed to require the module in CommonJS environments (with Browserify for example).

With that change you can now just type: `require('bootstrap-toggle');`, while actually it can't resolve the module.

I think you should also bump the version to be able to publish on npm.