### PR TITLE
Fix the click handling for checkboxes inside labels; Move click handling into render function

### DIFF
--- a/js/bootstrap-toggle.js
+++ b/js/bootstrap-toggle.js
@@ -82,6 +82,18 @@
 			$toggleOn.css('line-height', $toggleOn.height() + 'px')
 			$toggleOff.css('line-height', $toggleOff.height() + 'px')
 		}
+
+		var clickHandler = function(e){
+			this.toggle();
+			e.preventDefault()
+		}.bind(this)
+
+		if (this.$toggle.parent().prop('tagName') == 'LABEL') {
+			this.$toggle.parent().click(clickHandler);
+		} else {
+			this.$toggle.click(clickHandler);
+		}
+
 		this.update(true)
 		this.trigger(true)
 	}
@@ -169,12 +181,6 @@
 
 	$(function() {
 		$('input[type=checkbox][data-toggle^=toggle]').bootstrapToggle()
-	})
-
-	$(document).on('click.bs.toggle', 'div[data-toggle^=toggle]', function(e) {
-		var $checkbox = $(this).find('input[type=checkbox]')
-		$checkbox.bootstrapToggle('toggle')
-		e.preventDefault()
 	})
 
 }(jQuery);


### PR DESCRIPTION
This is an alternative to #75 and fixes #23.

From my point of view adding the click handlers inside the `render` function is better than in the `defaults` function (as suggested in #75). Additionally the code from #75 does not work for all cases.

Have a look at http://aaxee.github.io/bootstrap-toggle/ for a preview.
A toggle is triggered by clicking on the label or by clicking on the toggle-element.
