### PR TITLE
Remove deprecated version property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "bootstrap-toggle",
   "description": "Bootstrap Toggle is a highly flexible Bootstrap plugin that converts checkboxes into toggles",
-  "version": "2.2.1",
   "keywords": [
     "bootstrap",
     "toggle",


### PR DESCRIPTION
![avojqdv](https://cloud.githubusercontent.com/assets/6059356/17083998/0c2cb74c-51b2-11e6-904a-9a006193f09a.png)

From https://github.com/bower/spec/blob/master/json.md#version:

> Deprecated
> Use git or svn tags instead. This field is ignored by Bower.
