### PR TITLE
Including toggle style option

### DIFF
--- a/js/bootstrap-toggle.js
+++ b/js/bootstrap-toggle.js
@@ -26,6 +26,7 @@
 		off: 'Off',
 		onstyle: 'primary',
 		offstyle: 'default',
+		togglestyle: 'default',
 		size: 'normal',
 		style: '',
 		width: null,
@@ -38,6 +39,7 @@
 			off: this.$element.attr('data-off') || Toggle.DEFAULTS.off,
 			onstyle: this.$element.attr('data-onstyle') || Toggle.DEFAULTS.onstyle,
 			offstyle: this.$element.attr('data-offstyle') || Toggle.DEFAULTS.offstyle,
+			togglestyle: this.$element.attr('data-togglestyle') || Toggle.DEFAULTS.togglestyle,
 			size: this.$element.attr('data-size') || Toggle.DEFAULTS.size,
 			style: this.$element.attr('data-style') || Toggle.DEFAULTS.style,
 			width: this.$element.attr('data-width') || Toggle.DEFAULTS.width,
@@ -56,7 +58,7 @@
 			.addClass(this._onstyle + ' ' + size)
 		var $toggleOff = $('<label class="btn">').html(this.options.off)
 			.addClass(this._offstyle + ' ' + size + ' active')
-		var $toggleHandle = $('<span class="toggle-handle btn btn-default">')
+		var $toggleHandle = $('<span class="toggle-handle btn btn-' + this.options.togglestyle + '">')
 			.addClass(size)
 		var $toggleGroup = $('<div class="toggle-group">')
 			.append($toggleOn, $toggleOff, $toggleHandle)


### PR DESCRIPTION
For Bootstrap Toggle to work with bootstrap 4, we need to change btn-default to btn-secondary.

It would, then, be necessary to change the togglle button style.

I send a patch the allows the user to do that.
