### PR TITLE
Fixed JQuery clone problem.

### DIFF
--- a/js/bootstrap-toggle.js
+++ b/js/bootstrap-toggle.js
@@ -46,6 +46,11 @@
 	}
 
 	Toggle.prototype.render = function () {
+		if(this.$element.nextAll().last().is('div.toggle-group')) {
+			var parentElement = this.$element.parent();
+			this.$element.insertBefore(parentElement);
+			parentElement.remove();
+		}
 		this._onstyle = 'btn-' + this.options.onstyle
 		this._offstyle = 'btn-' + this.options.offstyle
 		var size = this.options.size === 'large' ? 'btn-lg'


### PR DESCRIPTION
If you've ever used .clone() in jQuery, you have encountered an issue where buttons become unresponsive after cloning. This occurs because the cloned element is already rendered, and that's what we need to address. To resolve this, we've implemented a check to determine if an element has already been rendered. If it has, we remove all elements added in the previous call to the .render() function and then proceed to render it once more.